### PR TITLE
not counting future deleted trails as good

### DIFF
--- a/ptam/src/Tracker.cc
+++ b/ptam/src/Tracker.cc
@@ -604,10 +604,15 @@ int Tracker::TrailTracking_Advance()
       ImageRef irBackWardsFound = irEnd;
       bFound = BackwardsPatch.FindPatch(irBackWardsFound, lPreviousFrame.im, 10, lPreviousFrame.vCorners);
       if((irBackWardsFound - irStart).mag_squared() > 2)
+      {
+        // this trail will be deleted
         bFound = false;
-
-      trail.irCurrentPos = irEnd;
-      nGoodTrails++;
+      }
+      else
+      {
+        trail.irCurrentPos = irEnd;
+        nGoodTrails++;
+      }
     }
     if(mbDraw)
     {


### PR DESCRIPTION
*Minor fix*: we don't want to increment **nGoodTrails** for a trail that we'll delete within the same block.
In such case we don't have to update **trail.irCurrentPos** either.
