### PR TITLE
rqt_ptam dependencies missing

### DIFF
--- a/rqt_ptam/CMakeLists.txt
+++ b/rqt_ptam/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rqt_ptam)
 
 find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED image_transport cv_bridge)
 
 
 catkin_package()

--- a/rqt_ptam/package.xml
+++ b/rqt_ptam/package.xml
@@ -28,7 +28,10 @@
   <build_depend>ptam_com</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>image_transport</build_depend>
 
+  <run_depend>image_transport</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_cpp</run_depend>


### PR DESCRIPTION
If you don't have image_view already load in rqt, the linker fails to find image_transport and cv_bridge, and rqt_ptam crashes.
It needs to explicity set in the package.xml and CMakeLists.xml.

thanks,
Guy
