### PR TITLE
Registered rqt_gui and rqt_gui_cpp dependencies

### DIFF
--- a/rqt_ptam/CMakeLists.txt
+++ b/rqt_ptam/CMakeLists.txt
@@ -2,10 +2,15 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rqt_ptam)
 
 find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  rqt_gui
+  rqt_gui_cpp
+)
 
-
-catkin_package()
+catkin_package(
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS rqt_gui_cpp
+)
 
 include(${QT_USE_FILE})
 
@@ -34,5 +39,3 @@ qt4_wrap_ui(rqt_ptam_UIS_H ${rqt_ptam_UIS})
 include_directories(include ${rqt_ptam_INCLUDE_DIRECTORIES} ${catkin_INCLUDE_DIRS})
 add_library(rqt_ptam ${rqt_ptam_SRCS} ${rqt_ptam_MOCS} ${rqt_ptam_UIS_H})
 target_link_libraries(rqt_ptam ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${catkin_LIBRARIES})
-
-

--- a/rqt_ptam/package.xml
+++ b/rqt_ptam/package.xml
@@ -28,6 +28,8 @@
   <build_depend>ptam_com</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>rqt_gui</build_depend>
+  <build_depend>rqt_gui_cpp</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rqt_gui</run_depend>


### PR DESCRIPTION
When building the **rqt_ptam** module (on ROS Kinetic), I had to explicitly add the rqt_gui and rqt_gui_cpp dependencies to the CMakeLists.txt and package.xml (build-depend). Compare with official [rqt_example_cpp](https://github.com/lucasw/rqt_mypkg/tree/master/rqt_example_cpp).